### PR TITLE
Bump Spice-Up Flatpak to 1.6.1 release

### DIFF
--- a/com.github.philip_scott.spice-up.json
+++ b/com.github.philip_scott.spice-up.json
@@ -1,6 +1,6 @@
 {
     "id": "com.github.philip_scott.spice-up",
-    "base": "io.elementary.Loki.BaseApp",
+    "base": "io.elementary.Juno.BaseApp",
 	"base-version": "stable",
     "runtime": "org.freedesktop.Platform",
     "runtime-version": "1.6",
@@ -97,8 +97,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Philip-Scott/Spice-up/archive/1.3.2.tar.gz",
-                    "sha256": "0557bdf871d20c7e9340a628ffc0c31ed14463e4787b662bb44ccd6d02c38ead"
+                    "url": "https://github.com/Philip-Scott/Spice-up/archive/1.6.1.tar.gz",
+                    "sha256": "65f9c8887d77b3b09200ebdfe58c9157331937dab5bfc890e9aee73226c12fb9"
                 },
                 {
                     "type": "patch",


### PR DESCRIPTION
NOTE: Depends on a "Juno" version of the elementary base existing, as there were api changes that happened and where fixed. 

