### PR TITLE
Replace udev with gudev

### DIFF
--- a/com.github.philip_scott.spice-up.json
+++ b/com.github.philip_scott.spice-up.json
@@ -18,7 +18,7 @@
             "--talk-name=org.freedesktop.ScreenSaver"
     ],
     "modules": [
-        "shared-modules/udev/udev-175.json",
+        "shared-modules/gudev/gudev.json",
         {
             "name": "libevdev",
             "config-opts": ["--disable-static"],


### PR DESCRIPTION
Since freedesktop-sdk 19.08 udev is part of runtime and only gudev is needed additionally.